### PR TITLE
feat: cache service #getByZipAndTS Happy Path

### DIFF
--- a/services/cache.js
+++ b/services/cache.js
@@ -1,0 +1,22 @@
+export default class ForecastCache {
+	constructor({ apiClient, dbClient }) {
+		this.apiClient = apiClient;
+		this.dbClient = dbClient;
+	}
+
+	async getByZipAndTS(zip, ts) {
+		const cachedForecast = await this.dbClient.getByZipAndTS(zip, ts);
+		if (cachedForecast) {
+			return cachedForecast;
+		}
+
+		const forecast = await this.apiClient.getByZipAndTS(zip, ts);
+		const transformedForecast = transformAPIRes(forecast);
+		await this.dbClient.saveForecast(transformedForecast);
+		return this.dbClient.getByZipAndTS(zip, ts);
+	}
+}
+
+export function transformAPIRes(res) {
+	return res;
+}

--- a/services/cache.spec.js
+++ b/services/cache.spec.js
@@ -1,0 +1,73 @@
+import ForecastCache from "./cache";
+import { mockTimeNow, mockZip } from "../test-helpers/fixtures";
+import { mockConvertedHour1 } from "./fixtures/forecast-api.fixtures";
+
+const fakeAPIClient = {
+	getByZipAndTS() {},
+};
+
+const fakeDbClient = {
+	getByZipAndTS() {},
+	saveForecast() {},
+};
+
+describe("Forecast Cache Service", () => {
+	describe("#getByZipAndTS", () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		test("should return a forecast object using cached data if present", async () => {
+			// Arrange
+			const cache = new ForecastCache({
+				dbClient: fakeDbClient,
+				apiClient: fakeAPIClient,
+			});
+			jest
+				.spyOn(fakeDbClient, "getByZipAndTS")
+				.mockImplementation(() => mockConvertedHour1);
+			jest.spyOn(fakeAPIClient, "getByZipAndTS");
+
+			// Act
+			const result = await cache.getByZipAndTS(mockZip, mockTimeNow);
+
+			// Assert
+			expect(result).toEqual(mockConvertedHour1);
+			expect(fakeDbClient.getByZipAndTS).toHaveBeenCalledWith(
+				mockZip,
+				mockTimeNow
+			);
+			expect(fakeDbClient.getByZipAndTS).toHaveBeenCalledTimes(1);
+			expect(fakeAPIClient.getByZipAndTS).not.toHaveBeenCalled();
+		});
+
+		test("should return a forecast object using API data if not present", async () => {
+			// Arrange
+			const cache = new ForecastCache({
+				dbClient: fakeDbClient,
+				apiClient: fakeAPIClient,
+			});
+
+			jest.spyOn(fakeDbClient, "saveForecast");
+
+			jest
+				.spyOn(fakeAPIClient, "getByZipAndTS")
+				.mockImplementation(() => mockConvertedHour1);
+
+			const dbCall = jest.spyOn(fakeDbClient, "getByZipAndTS");
+			dbCall.mockReturnValueOnce(undefined); // First call returns undefined
+			dbCall.mockReturnValueOnce(mockConvertedHour1); // Second call returns an object
+
+			// Act
+			const result = await cache.getByZipAndTS(mockZip, mockTimeNow);
+
+			// Assert
+			expect(fakeDbClient.getByZipAndTS).toHaveBeenCalledTimes(2);
+			expect(result).toEqual(mockConvertedHour1);
+			expect(fakeAPIClient.getByZipAndTS).toHaveBeenCalledWith(
+				mockZip,
+				mockTimeNow
+			);
+		});
+	});
+});


### PR DESCRIPTION
This PR creates a `Cache` service that will be used by our route handler. It tests the happy path of the `getByZipAndTS` method on the `Cache` class, as well.

Loom Video Walk through:
https://www.loom.com/share/d62d13599aa74999ae6fa2b3ebe424e5

